### PR TITLE
Allow optimistic final imperilment wagering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,5 +5,6 @@
 //= require bootstrap/collapse
 //= require bootstrap/dropdown
 //= require bootstrap/alert
+//= require bootstrap/tooltip
 //= require bootstrap-datepicker/core
 //= require_tree .

--- a/app/assets/javascripts/general.js.coffee
+++ b/app/assets/javascripts/general.js.coffee
@@ -55,4 +55,6 @@
         container.find('.lock, .unlock').toggleClass('show hide')
         container.toggleClass('info')
       false
+
+    $('[data-toggle="tooltip"]').tooltip()
 ) ($window ? window)

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -16,6 +16,7 @@ class AnswersController < ApplicationController
     elsif @answer.final? && @answer.question_for(current_user).nil?
       redirect_to [:final, @game, @answer]
     else
+      @question = @answer.question_for(current_user)
       respond_with @game, @answer
     end
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -47,6 +47,7 @@ class QuestionsController < ApplicationController
     qp = question_params
     qp[:correct] = nil if qp[:correct] == 'null'
     if @question.update(qp)
+      @question.game.clamp_final_wager!(@question.user)
       flash.notice = t :model_update_successful, model: Question.model_name.human if request.format == :html
     end
     respond_with @game, @answer, @question, location: root_path

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -46,6 +46,14 @@ class Game < ActiveRecord::Base
     ).sum(:amount)
   end
 
+  def clamp_final_wager!(user)
+    final = answers.find_by(amount: [nil, 0])&.question_for(user)
+    if final&.amount
+      amount = final.amount.clamp(0, max_wager(user))
+      final.update(amount: amount) unless final.amount === amount
+    end
+  end
+
   def started_on
     answers.map(&:start_date).min
   end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -34,6 +34,18 @@ class Game < ActiveRecord::Base
     end
   end
 
+  # The sum of all amounts from non-final, not-wrong questions for a given user.
+  # This is the largest possible legal wager if future marking were to reveal no more mistakes.
+  def max_wager(user)
+    answers.left_outer_joins(:questions).where(
+      questions: { id: nil }
+    ).or(
+      answers.where(
+        questions: { correct: [true, nil] }
+      )
+    ).sum(:amount)
+  end
+
   def started_on
     answers.map(&:start_date).min
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,6 +1,7 @@
 class Question < ActiveRecord::Base
   belongs_to :user
   belongs_to :answer
+  delegate :game, to: :answer
 
   validate :unchecked_response, :in_range?
   validates :answer_id, uniqueness: { scope: :user_id }
@@ -38,7 +39,7 @@ class Question < ActiveRecord::Base
   end
 
   def in_range?
-    unless amount.nil? || amount.between?(0, answer.game.score(user))
+    unless amount.nil? || amount.between?(0, game.max_wager(user))
       errors.add(:amount, "is not within the acceptable range. Nice try!")
       false
     else

--- a/app/views/answers/_final_wager.html.erb
+++ b/app/views/answers/_final_wager.html.erb
@@ -1,0 +1,4 @@
+You may wager up to $<%= max_wager %>
+<% if max_wager > current_score %>
+  <a href="#" data-toggle="tooltip" title="<%= t('.wager_disclaimer', current_score: current_score) %>">*</a>
+<% end %>

--- a/app/views/answers/final.html.erb
+++ b/app/views/answers/final.html.erb
@@ -7,7 +7,10 @@
     </div>
   </div>
   <div class='col-md-8'>
-    <h3>You may wager up to $<%= @game.score(current_user) %></h3>
+    <h3><%= render 'final_wager',
+      current_score: @game.score(current_user),
+      max_wager: @game.max_wager(current_user)
+    %></h3>
     <% if @question && @question.errors.any? %>
       <div class="errors">
         <% @question.errors[:amount].each do |error| %>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -6,11 +6,9 @@
     <div class="area">
       <div class='category'><p><%= @answer.category.name %></p></div>
     </div>
-    <% if @answer.amount %>
-      <div class="area">
-        <div class='dollar-value'><p>$<%= @answer.amount %></p></div>
-      </div>
-    <% end %>
+    <div class="area">
+      <div class='dollar-value'><p>$<%= @answer.amount || @question.amount %></p></div>
+    </div>
   </div>
   <div class='col-md-8'>
     <div class='area-answer'>
@@ -20,12 +18,10 @@
 </div>
 
 <div class='form-group question-actions'>
-  <% question = @answer.question_for(current_user) %>
-
-  <% if !question %>
+  <% if !@question %>
     <%= link_to "What is ...", [:new, @game, @answer, :question], class: 'btn btn-primary btn-lg btn-block' %>
-  <% elsif !question.checked? %>
-    <%= link_to "Your Response", [:edit, @game, @answer, question], class: 'btn btn-primary btn-lg btn-block' %>
+  <% elsif !@question.checked? %>
+    <%= link_to "Your Response", [:edit, @game, @answer, @question], class: 'btn btn-primary btn-lg btn-block' %>
   <% elsif @answer.closed? %>
     <%= link_to "View Responses", [@game, @answer, Question], class: 'btn btn-primary btn-lg btn-block' %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,8 @@ en:
         url: Payload URL
 
   answers:
+    final_wager:
+      wager_disclaimer: You are only guarateed to have $%{current_score} from your currently marked responses.
     too_soon:
       available_in: Available in %{time_until}
 

--- a/spec/controllers/questions_controller_spec.rb
+++ b/spec/controllers/questions_controller_spec.rb
@@ -167,6 +167,11 @@ describe QuestionsController do
         expect(response).to redirect_to root_path
       end
 
+      it "adjusts the user's final wager if necessary" do
+        expect_any_instance_of(Game).to receive(:clamp_final_wager!).with(question.user)
+        put :update, params: default_params.merge(id: question.to_param)
+      end
+
       describe 'updating correct' do
         subject { assigns(:question).correct }
         context 'when user is an admin' do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -92,6 +92,55 @@ describe Game do
     end
   end
 
+  describe '.clamp_final_wager!' do
+    subject { game.clamp_final_wager!(user) }
+
+    context 'a game without a final answer' do
+      it 'does not explode' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'a game with a final answer but no user response for it' do
+      before do
+        create :answer, game: game, amount: nil
+      end
+
+      it 'does not explode' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'a game with a final wager for this user and a max_wager of 500' do
+      let(:final_response) {
+        final_nswer = create :answer, game: game, amount: nil
+        build(:question, user: user, answer: final_nswer, amount: final_wager).tap do |q|
+          q.save(validate: false)
+        end
+      }
+
+      before do
+        allow(game).to receive(:max_wager).and_return 500
+      end
+
+      context 'with final wager of 0' do
+        let(:final_wager) { 0 }
+
+        it 'does not change the final wager' do
+          expect{ subject }.not_to change{ final_response.reload.amount }.from(0)
+        end
+      end
+
+      context 'with final wager that is larger than the max_wager' do
+        let(:final_wager) { 1000 }
+
+        it 'reduces the final wager to the amount allowed' do
+          expect{ subject }.to change{ final_response.reload.amount }.from(1000).to(500)
+        end
+      end
+    end
+  end
+
   describe '#all_answers' do
     context "an unsaved game" do
       let(:game) { Game.new }

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -73,6 +73,25 @@ describe Game do
     end
   end
 
+  describe '.max_wager' do
+    let!(:unanswered) { create :answer, game: game, amount: 100 }
+    let!(:answered) { create :answer, game: game, amount: 200 }
+    let!(:correct) { create :answer, game: game, amount: 400 }
+    let!(:incorrect) { create :answer, game: game, amount: 800 }
+    let!(:final) { create :answer, game: game, amount: nil }
+
+    before do
+      create :question, user: user, answer: answered, correct: nil
+      create :question, user: user, answer: correct, correct: true
+      create :question, user: user, answer: incorrect, correct: false
+      create :question, user: user, answer: final, correct: true, amount: 555
+    end
+
+    it 'returns the sum of all non-final, not-wrong answer amounts' do
+      expect(game.max_wager(user)).to eq(700)
+    end
+  end
+
   describe '#all_answers' do
     context "an unsaved game" do
       let(:game) { Game.new }

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -129,7 +129,7 @@ describe Question do
 
     context 'when the amount is not nil' do
       before(:each) do
-        allow(game).to receive(:score) { 200 }
+        allow(game).to receive(:max_wager) { 200 }
 
         question.amount = amount
       end


### PR DESCRIPTION
Right now a player can wager up to their current score (all of the money they've earned from correct responses).
However this may be leaving some money on the table in the form of unmarked responses. This change includes those amounts in the max wager limit by summing the amounts for all non-final, not-wrong (missing, correct, or unmarked) questions.

<img width="835" alt="Screen Shot 2022-01-08 at 11 34 05 AM" src="https://user-images.githubusercontent.com/1529452/148662995-5e3ad1ba-1560-410e-9535-61089252d101.png">

This should be helpful for players who would like to confidently place a large wager and proceed with final imperilment before waiting for an admin to mark their responses.
