### PR TITLE
Replace public use of email, first_name, last_name, with display_name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,13 +7,9 @@ require File.expand_path('../config/application', __FILE__)
 task development_data: :environment do
   users = (0..10).map do
     display_name = [true, false].sample ? FFaker::Name.name : nil
-    first_name = FFaker::Name.first_name
-    last_name = FFaker::Name.last_name
     User.create!(
-      email: FFaker::Internet.email("#{first_name} #{last_name}"),
+      email: FFaker::Internet.email,
       display_name: display_name,
-      first_name: first_name,
-      last_name:  last_name,
       password: 'asdfg12345'
     )
   end

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,12 @@ require File.expand_path('../config/application', __FILE__)
 
 task development_data: :environment do
   users = (0..10).map do
+    display_name = [true, false].sample ? FFaker::Name.name : nil
     first_name = FFaker::Name.first_name
     last_name = FFaker::Name.last_name
     User.create!(
       email: FFaker::Internet.email("#{first_name} #{last_name}"),
+      display_name: display_name,
       first_name: first_name,
       last_name:  last_name,
       password: 'asdfg12345'

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -42,6 +42,6 @@ class Admin::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit :email, :display_name, :password, :password_confirmation, :remember_me, :first_name, :last_name
+    params.require(:user).permit :email, :display_name, :password, :password_confirmation, :remember_me
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -42,6 +42,6 @@ class Admin::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit :email, :password, :password_confirmation, :remember_me, :first_name, :last_name
+    params.require(:user).permit :email, :display_name, :password, :password_confirmation, :remember_me, :first_name, :last_name
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   def account_update_params
-    params.require(:user).permit(:email, :display_name, :password, :password_confirmation, :current_password)
+    params.require(:user).permit(:email, :display_name, :password, :password_confirmation)
+  end
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,8 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+
+  protected
+
+  def account_update_params
+    params.require(:user).permit(:email, :display_name, :password, :password_confirmation, :current_password)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ActiveRecord::Base
   has_many :questions, dependent: :destroy
 
   def identifier
-    full_name.blank? ? email : full_name
+    display_name.presence || 'Anonymous'
   end
 
   def full_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,16 +17,10 @@ class User < ActiveRecord::Base
     display_name.presence || 'Anonymous'
   end
 
-  def full_name
-    [first_name, last_name].reject(&:blank?).join ' '
-  end
-
   def self.find_for_google_oauth2(access_token, _signed_in_resource = nil)
     data = access_token.info
     User.where(email: data["email"]).first_or_create! do |user|
       user.email = data["email"]
-      user.first_name = data["first_name"]
-      user.last_name = data["last_name"].try!(:first)
       user.password = Devise.friendly_token[0, 20]
     end
   end

--- a/app/models/web_hook/event/new_question.rb
+++ b/app/models/web_hook/event/new_question.rb
@@ -13,7 +13,7 @@ module WebHook::Event
       @question.as_json(only: [:id, :created_at, :updated_at])
         .tap do |h|
           h['answer'] = answer_json
-          h['user'] = respondant_email
+          h['user'] = respondant
         end
     end
 
@@ -22,8 +22,8 @@ module WebHook::Event
       NewAnswer.new(@question.answer).as_json
     end
 
-    def respondant_email
-      @question.user.email
+    def respondant
+      @question.user.identifier
     end
   end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -2,6 +2,7 @@
   <%= f.error_notification %>
 
   <%= f.input :email %>
+  <%= f.input :display_name %>
   <%= f.input :first_name %>
   <%= f.input :last_name %>
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -3,8 +3,6 @@
 
   <%= f.input :email %>
   <%= f.input :display_name %>
-  <%= f.input :first_name %>
-  <%= f.input :last_name %>
 
   <%= f.button :submit, class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,6 +4,7 @@
     <thead>
       <tr>
         <th><%= User.human_attribute_name ( "email" ) %></th>
+        <th><%= User.human_attribute_name ( "display_name" ) %></th>
         <th><%= User.human_attribute_name ( "full_name" ) %></th>
       </tr>
     </thead>
@@ -11,6 +12,7 @@
       <% @users.each do |user| %>
           <tr class='<%= 'success' if user.has_role? :admin %>'>
           <td><%= user.email %></td>
+          <td><%= user.display_name %></td>
           <td><%= user.full_name %></td>
           <td>
             <% unless user == current_user %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -5,7 +5,6 @@
       <tr>
         <th><%= User.human_attribute_name ( "email" ) %></th>
         <th><%= User.human_attribute_name ( "display_name" ) %></th>
-        <th><%= User.human_attribute_name ( "full_name" ) %></th>
       </tr>
     </thead>
     <tbody>
@@ -13,7 +12,6 @@
           <tr class='<%= 'success' if user.has_role? :admin %>'>
           <td><%= user.email %></td>
           <td><%= user.display_name %></td>
-          <td><%= user.full_name %></td>
           <td>
             <% unless user == current_user %>
               <%= render 'add_role', user: user %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -6,6 +6,7 @@
   <% end %>
 
   <%= s.attribute :email %>
+  <%= s.attribute :display_name %>
   <%= s.attribute :full_name %>
   <%= s.attribute :created_at, format: :short %>
   <%= s.attribute :updated_at, format: :short %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -7,7 +7,6 @@
 
   <%= s.attribute :email %>
   <%= s.attribute :display_name %>
-  <%= s.attribute :full_name %>
   <%= s.attribute :created_at, format: :short %>
   <%= s.attribute :updated_at, format: :short %>
   <%= s.attribute :last_sign_in_at, format: :short %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,7 +9,6 @@
   <%= f.input :display_name %>
   <%= f.input :password, :autocomplete => "off", :hint => "leave it blank if you don't want to change it", :required => false %>
   <%= f.input :password_confirmation, :required => false %>
-  <%= f.input :current_password, :hint => "we need your current password to confirm your changes", :required => true %>
 
   <%= f.button :submit, "Update", class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,6 +6,7 @@
   <%= f.error_notification %>
 
   <%= f.input :email, :required => true, :autofocus => true %>
+  <%= f.input :display_name %>
   <%= f.input :password, :autocomplete => "off", :hint => "leave it blank if you don't want to change it", :required => false %>
   <%= f.input :password_confirmation, :required => false %>
   <%= f.input :current_password, :hint => "we need your current password to confirm your changes", :required => true %>

--- a/app/views/layouts/_nav_user.html.erb
+++ b/app/views/layouts/_nav_user.html.erb
@@ -1,7 +1,7 @@
 <% if current_user %>
   <a class='btn-link dropdown-toggle' href='#' data-toggle='dropdown'>
     <%= icon :user %>
-    <%= current_user.email %>
+    <%= current_user.identifier %>
     <span class='caret'></span>
   </a>
   <ul class='dropdown-menu'>

--- a/app/views/leader_boards/_display_name_hint.html.erb
+++ b/app/views/leader_boards/_display_name_hint.html.erb
@@ -1,0 +1,6 @@
+<%= link_to edit_user_registration_path, {
+    'data-toggle' => 'tooltip',
+    'title' => t('.tooltip'),
+  } do %>
+  <%= icon :asterisk %>
+<% end %>

--- a/app/views/leader_boards/show.html.erb
+++ b/app/views/leader_boards/show.html.erb
@@ -20,7 +20,10 @@
         <% end %>
         <%= "#{t :currency_symbol} #{result.total}" %>
       </td>
-      <td class='email'><%= result.user.identifier %></td>
+      <td class='email'>
+        <%= result.user.identifier %>
+        <%= render('display_name_hint') if result.user == current_user && result.user.display_name.blank? %>
+        </td>
       <% unless @game.answers.empty? %>
         <td class='hidden-phone'>
           <table class='breakdown'>
@@ -53,4 +56,3 @@
 </table>
 <%= link_to t(:overall_results), overall_leader_board_path, class: 'btn btn-default' %>
 <%= link_to t(:overall_results_by_money), overall_money_leader_board_path, class: 'btn btn-default' %>
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,8 @@ en:
   reponse_hidden: Response Hidden
 
   leader_boards:
+    display_name_hint:
+      tooltip: 'Click to enter your display name'
     index:
       info: 'These are the overall results to date for all finished games. The current week is not taken into account.'
     money:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Imperilment::Application.routes.draw do
-  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
+  devise_for :users, controllers: {
+    omniauth_callbacks: 'users/omniauth_callbacks',
+    registrations: 'users/registrations',
+  }
+
   namespace :admin do
     resources :users, except: %i(new create) do
       put :grant_admin, on: :member, as: :grant

--- a/db/migrate/20220130205629_add_display_name_to_users.rb
+++ b/db/migrate/20220130205629_add_display_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2015_03_07_173552) do
+ActiveRecord::Schema.define(version: 2022_01_30_205629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 2015_03_07_173552) do
     t.datetime "updated_at"
     t.string "first_name"
     t.string "last_name"
+    t.string "display_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -46,18 +46,27 @@ describe Admin::UsersController do
 
   describe 'PUT update' do
     describe "with valid params" do
+      let(:valid_params) {
+        {
+          'email' => 'joe@example.com',
+          'display_name' => 'Dirté',
+          'first_name' => 'Joe',
+          'last_name' => 'Dirt',
+        }
+      }
+
       it "updates the requested user" do
-        expect_any_instance_of(User).to receive(:update).with('first_name' => 'Joe')
-        put :update, params: { id: user.to_param, user: { 'first_name' => 'Joe' } }
+        expect_any_instance_of(User).to receive(:update).with(valid_params)
+        put :update, params: { id: user.to_param, user: valid_params }
       end
 
       it "assigns the requested user as @user" do
-        put :update, params: { id: user.to_param, user: { 'first_name' => 'Joe' } }
+        put :update, params: { id: user.to_param, user: valid_params }
         expect(assigns(:user)).to eq(user)
       end
 
       it "redirects to the user" do
-        put :update, params: { id: user.to_param, user: { 'first_name' => 'Joe' } }
+        put :update, params: { id: user.to_param, user: valid_params }
         expect(response).to redirect_to([:admin, user])
       end
     end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -50,8 +50,6 @@ describe Admin::UsersController do
         {
           'email' => 'joe@example.com',
           'display_name' => 'Dirté',
-          'first_name' => 'Joe',
-          'last_name' => 'Dirt',
         }
       }
 

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -6,8 +6,8 @@ describe Users::RegistrationsController do
 
     authorize_and_login
 
-    it "allows a user to update their display_name" do
-      put :update, params: { user: { display_name: 'new username', current_password: user.password } }
+    it "allows a user to update their display_name without a password confirmation" do
+      put :update, params: { user: { display_name: 'new username' } }
       expect(response).to redirect_to('/')
       expect(user.reload.display_name).to eq('new username')
     end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Users::RegistrationsController do
+  describe ".update" do
+    let!(:user) { create :user, display_name: 'old username' }
+
+    authorize_and_login
+
+    it "allows a user to update their display_name" do
+      put :update, params: { user: { display_name: 'new username', current_password: user.password } }
+      expect(response).to redirect_to('/')
+      expect(user.reload.display_name).to eq('new username')
+    end
+  end
+end

--- a/spec/models/slack_notification/game_finalization_spec.rb
+++ b/spec/models/slack_notification/game_finalization_spec.rb
@@ -8,9 +8,9 @@ end
 
 RSpec.describe SlackNotification::GameFinalization, type: :model do
   let(:game) { FactoryBot.create :game, id: 772 }
-  let(:first_place) { FactoryBot.create :user, first_name: 'First', last_name: 'P' }
+  let(:first_place) { FactoryBot.create :user, display_name: 'First P' }
   let(:no_name) {     FactoryBot.create :user, email: 'foo@bar.com' }
-  let(:tied_for_2) {  FactoryBot.create :user, first_name: 'Also', last_name: '2' }
+  let(:tied_for_2) {  FactoryBot.create :user, display_name: 'Also 2' }
   before do
     FactoryBot.create :game_result, game: game, position: 1, total: '4200', user: first_place
     FactoryBot.create :game_result, game: game, position: 2, total: '2500', user: no_name
@@ -34,7 +34,7 @@ RSpec.describe SlackNotification::GameFinalization, type: :model do
         'pretext' => 'Imperilment results are in!',
         'title' => "Last week's winners",
         'title_link' => 'http://test.com/leader_board/772',
-        'text' => ":trophy: $4200 First P\n\n:silver: $2500 foo@bar.com\n\n:silver: $2500 Also 2",
+        'text' => ":trophy: $4200 First P\n\n:silver: $2500 Anonymous\n\n:silver: $2500 Also 2",
         'color' => '#337AB7',
         'fallback' => "Last week's winners are in! http://test.com/leader_board/772"
       }]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,17 +17,21 @@ describe User do
   end
 
   describe '.identifier' do
-    let(:user) { create :user, first_name: name, email: email }
-    let(:email) { 'alex.t@imperilment.com' }
+    let(:user) { create :user, display_name: name }
 
     subject { user.identifier }
 
-    context 'when the first_name is blank' do
+    context 'when the display_name is nil' do
       let(:name) { nil }
-      it { is_expected.to eq(email) }
+      it { is_expected.to eq('Anonymous') }
     end
 
-    context 'when the first_name is not blank' do
+    context 'when the display_name is empty' do
+      let(:name) { '' }
+      it { is_expected.to eq('Anonymous') }
+    end
+
+    context 'when the display_name is not blank' do
       let(:name) { 'Alex' }
       it { is_expected.to eq(name) }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,14 +38,12 @@ describe User do
   end
 
   describe '#find_for_google_oauth2' do
-    let(:result) { User.find_for_google_oauth2(AccessToken.new("email" => email, "last_name" => name)) }
-    let(:name) { 'Smith' }
-    let(:last_name) { 'Smith' }
+    let(:result) { User.find_for_google_oauth2(AccessToken.new("email" => email)) }
 
     context "when user exists" do
       subject { result }
 
-      let!(:user) { create :user, last_name: last_name }
+      let!(:user) { create :user}
       let(:email) { user.email }
 
       it { is_expected.to eq(user) }
@@ -56,10 +54,7 @@ describe User do
 
       it 'creates a user with the correct attributes' do
         expect { result }.to change { User.count }.by(1)
-        expect(User.last).to have_attributes(
-          email: email,
-          last_name: 'S'
-        )
+        expect(User.last).to have_attributes(email: email)
       end
     end
   end

--- a/spec/models/web_hook/event/new_question_spec.rb
+++ b/spec/models/web_hook/event/new_question_spec.rb
@@ -16,8 +16,12 @@ describe WebHook::Event::NewQuestion do
       expect(subject).to include('Such clue')
     end
 
-    it "contains the user's email" do
-      expect(subject).to include('my@email.com')
+    it "does not contain the user's email" do
+      expect(subject).not_to include('my@email.com')
+    end
+
+    it "contains a display_name for the user" do
+      expect(subject).to include('Anonymous')
     end
 
     it "does not contain the user's response" do


### PR DESCRIPTION
Previously, to identify users on a leaderboard we used a combination of First+Last (which we got from gmail for some users) or their email address (login username). Only visitors who realized that their "email" could be any string had control over their public identity. I'd like to change the default of Imperilment to be "privacy first" and wait for a user to choose to expose information (by setting a display_name).

To encourage adoption of a display_name without being overly annoying, I would like to show an asterisk next to the current
user's entry in the leaderboard if they have not chosen a display_name. This asterisk has a tooltip and is a link to the user edit page where they can pick a display_name.

<img width="364" alt="Screen Shot 2022-01-30 at 11 40 19 PM" src="https://user-images.githubusercontent.com/1529452/151758119-cbf4da2f-e011-4cfd-8576-a22f222644c9.png">
